### PR TITLE
Fix isort path

### DIFF
--- a/src/model_w/project_maker/template/api/Makefile
+++ b/src/model_w/project_maker/template/api/Makefile
@@ -6,4 +6,4 @@ black:
 	$(PYTHON_BIN) -m black --exclude '/(\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist|node_modules|webpack_bundles)/' .
 
 isort:
-	$(PYTHON_BIN) -m isort src
+	$(PYTHON_BIN) -m isort .


### PR DESCRIPTION
`src` does not exist in the template, the path for `isort` should be `.` (same as `black`)