### PR TITLE
chore: update poetry dev dependencies to include group

### DIFF
--- a/src/model_w/project_maker/template/api/pyproject.toml
+++ b/src/model_w/project_maker/template/api/pyproject.toml
@@ -27,7 +27,7 @@ modelw-preset-django = {extras = [
 ], version = ">=2023.4.0b1,<2023.7.0", allow-prereleases = true}
 drf-spectacular = {extras = ["sidecar"], version = "^0.26.2"}
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = "*"
 isort = "*"
 ipython = "*"


### PR DESCRIPTION
Update `pyproject.toml` in the template to include dev dependency group

https://python-poetry.org/docs/master/managing-dependencies/#dependency-groups