### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,3 +233,13 @@ sw.*
 
 # dotenv environment variables file
 .env
+
+# ---
+# Model-W project maker Related
+# ---
+
+# envs templates
+front/.env-template
+front/.env.test
+api/.env-template
+api/.env.test


### PR DESCRIPTION
Gitguardian is triggered by the SECRET_KEY=lalalala when pushing a project for the first time. This way this would be removed